### PR TITLE
Update autounattend.xml 30-07-2024

### DIFF
--- a/IoT-LTSC-Like/autounattend.xml
+++ b/IoT-LTSC-Like/autounattend.xml
@@ -43,7 +43,7 @@
         <RunSynchronousCommand wcm:action="add">
           <Order>7</Order>
           <Description>Prevents auto detection of Windows Edition and forces Windows Setup to show all available Editions of Windows during setup.</Description>
-          <Path>cmd /c echo [Channel]>%SYSTEMDRIVE%\sources\ei.cfg &amp;&amp; echo Retail>>%SYSTEMDRIVE%\sources\ei.cfg &amp;&amp; echo [VL]>>%SYSTEMDRIVE%\sources\ei.cfg &amp;&amp; echo 0>>%SYSTEMDRIVE%\sources\ei.cfg</Path>
+          <Path>cmd /c echo [Channel]>%SYSTEMDRIVE%\sources\ei.cfg && echo Retail>>%SYSTEMDRIVE%\sources\ei.cfg</Path>
         </RunSynchronousCommand>
       </RunSynchronous>
     </component>


### PR DESCRIPTION
**Issue:**
The current configuration does not work in the new Windows builds.

**Current Configuration:**
```
[Channel]
_Default
[VL]
0
```

**Proposed Change:**

The configuration should be updated to:
```
[Channel]
Retail
```

Please update the configuration as soon as possible to ensure compatibility with the new Windows builds.