### PR TITLE
Removed forced Pro edition, remove browser policies, defined new list of services.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Updates
 
+## 28/11/2024
+### v2.1.0 Changes
+#### `autounattend.xml` Changes
+- Removed the forced Pro edition enforcement. This is so the answer file can still be used with Home and especially Enterprise versions like LTSC.
+- Added an order to temporarily disable all network adapters so Windows Updates aren't installed during the OOBE phase. (This should stop Windows Defender from being Enabled automatically.)
+- Added a FirstLogon command that enables the network adapter again when the first user loads in after the OOBE phase.
+
+#### `autounattend.xml` & `UWScript.ps1` Changes
+- Removed Microsoft Edge and Google Chrome Policies as it seems to negatively impact user browsing experience.
+- Defined a new list of services that should be set to Disabled and Manual as the original list in v2.0.0 caused issues. The process count isn't as low as before but Windows should be more functional.
+
 ## 1/11/2024
 - Released UnattendedWinstall v2.0.0
 

--- a/UWScript.ps1
+++ b/UWScript.ps1
@@ -1185,37 +1185,6 @@ Windows Registry Editor Version 5.00
 [HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\WindowsStore]
 "AutoDownload"=dword:00000002
 
-; EDGE
-[HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Edge]
-"StartupBoostEnabled"=dword:00000000
-"HardwareAccelerationModeEnabled"=dword:00000000
-"BackgroundModeEnabled"=dword:00000000
-
-[HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\MicrosoftEdgeElevationService]
-"Start"=dword:00000004
-
-[HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\edgeupdate]
-"Start"=dword:00000004
-
-[HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\edgeupdatem]
-"Start"=dword:00000004
-
-; CHROME
-[HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Google\Chrome]
-"StartupBoostEnabled"=dword:00000000
-"HardwareAccelerationModeEnabled"=dword:00000000
-"BackgroundModeEnabled"=dword:00000000
-"HighEfficiencyModeEnabled"=dword:00000001
-
-[HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\GoogleChromeElevationService]
-"Start"=dword:00000004
-
-[HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\gupdate]
-"Start"=dword:00000004
-
-[HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\gupdatem]
-"Start"=dword:00000004
-
 ; UWP APPS
 ; disable background apps
 [HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\AppPrivacy]
@@ -1454,30 +1423,6 @@ Windows Registry Editor Version 5.00
 ; --OTHER--
 ; Enable update Microsoft Store apps automatically
 [-HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\WindowsStore]
-
-; EDGE
-[-HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Edge]
-
-[HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\MicrosoftEdgeElevationService]
-"Start"=dword:00000002
-
-[HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\edgeupdate]
-"Start"=dword:00000002
-
-[HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\edgeupdatem]
-"Start"=dword:00000002
-
-; CHROME
-[-HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Google\Chrome]
-
-[HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\GoogleChromeElevationService]
-"Start"=dword:00000002
-
-[HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\gupdate]
-"Start"=dword:00000002
-
-[HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\gupdatem]
-"Start"=dword:00000002
 
 ; --CAN'T DO NATIVELY--
 ; UWP APPS
@@ -2399,19 +2344,62 @@ Windows Registry Editor Version 5.00
 # End of Registry Optimizations
 
 # Start of Tasks and Services Functions
+# Start of Tasks and Services Functions
 function Set-ServiceStartup {
     # List of services to set to Disabled
     $disabledServices = @(
-        'AJRouter', 'AssignedAccessManagerSvc', 'AppIDSvc', 'BDESVC', 'DiagTrack', 
-        'DPS', 'EFS', 'FontCache', 'PcaSvc', 'RmSvc', 'WSearch', 'WbioSrvc', 'lfsvc'
-    )
+    'AJRouter', 'AppVClient', 'AssignedAccessManagerSvc', 
+    'DiagTrack', 'DialogBlockingService', 'NetTcpPortSharing',
+    'RemoteAccess', 'RemoteRegistry', 'shpamsvc', 
+    'ssh-agent', 'tzautoupdate', 'uhssvc',
+    'UevAgentService'
+	)
 
     # List of services to set to Manual
     $manualServices = @(
-        'BITS', 'CDPSvc', 'DusmSvc', 'LanmanServer', 'LanmanWorkstation', 
-        'Spooler', 'StateRepository', 'StorSvc', 'SysMain', 'TokenBroker', 
-        'TrkWks', 'UsoSvc', 'WpnService', 'edgeupdate', 'edgeupdatem', 
-        'iphlpsvc', 'sppsvc'
+    'ALG', 'AppIDSvc', 'AppMgmt', 'AppReadiness', 'AppXSvc', 'Appinfo',
+    'AxInstSV', 'BDESVC', 'BITS', 'BTAGService', 'BcastDVRUserService_*',
+    'Browser', 'CDPSvc', 'CDPUserSvc_*', 'COMSysApp', 'CaptureService_*',
+    'CertPropSvc', 'ClipSVC', 'ConsentUxUserSvc_*', 'CscService', 'DcpSvc',
+    'DevQueryBroker', 'DeviceAssociationBrokerSvc_*', 'DeviceAssociationService', 
+    'DeviceInstall', 'DevicePickerUserSvc_*', 'DevicesFlowUserSvc_*', 
+    'DisplayEnhancementService', 'DmEnrollmentSvc', 'DoSvc', 'DsSvc', 'DsmSvc',
+    'EFS', 'EapHost', 'EntAppSvc', 'FDResPub', 'Fax', 'FrameServer',
+    'FrameServerMonitor', 'GraphicsPerfSvc', 'HomeGroupListener', 
+    'HomeGroupProvider', 'HvHost', 'IEEtwCollectorService', 'IKEEXT',
+    'InstallService', 'InventorySvc', 'IpxlatCfgSvc', 'KtmRm', 'LicenseManager',
+    'LxpSvc', 'MSDTC', 'MSiSCSI', 'MapsBroker', 'McpManagementService', 
+    'MessagingService_*', 'MicrosoftEdgeElevationService', 
+    'MixedRealityOpenXRSvc', 'MsKeyboardFilter', 'NPSMSvc_*', 'NaturalAuthentication',
+    'NcaSvc', 'NcbService', 'NcdAutoSetup', 'Netman', 'NgcCtnrSvc', 'NgcSvc',
+    'NlaSvc', 'P9RdrService_*', 'PNRPAutoReg', 'PNRPsvc', 'PcaSvc', 'PeerDistSvc',
+    'PenService_*', 'PerfHost', 'PhoneSvc', 'PimIndexMaintenanceSvc_*', 'PlugPlay',
+    'PolicyAgent', 'PrintNotify', 'PrintWorkflowUserSvc_*', 'PushToInstall', 'QWAVE',
+    'RasAuto', 'RasMan', 'RetailDemo', 'RmSvc', 'RpcLocator', 'SCPolicySvc',
+    'SCardSvr', 'SDRSVC', 'SEMgrSvc', 'SecurityHealthService', 
+    'SensorDataService', 'SensorService', 'SensrSvc', 'SessionEnv', 
+    'SharedAccess', 'SharedRealitySvc', 'SmsRouter', 'SstpSvc', 
+    'StateRepository', 'StiSvc', 'StorSvc', 'TabletInputService', 'TapiSrv',
+    'TextInputManagementService', 'TieringEngineService', 'TimeBroker',
+    'TimeBrokerSvc', 'TokenBroker', 'TroubleshootingSvc', 'TrustedInstaller',
+    'UI0Detect', 'UdkUserSvc_*', 'UmRdpService', 'UnistoreSvc_*', 
+    'UserDataSvc_*', 'UsoSvc', 'VSS', 'VacSvc', 'W32Time', 'WEPHOSTSVC',
+    'WFDSConMgrSvc', 'WMPNetworkSvc', 'WManSvc', 'WPDBusEnum', 'WSService',
+    'WSearch', 'WaaSMedicSvc', 'WalletService', 'WarpJITSvc', 'WbioSrvc',
+    'WcsPlugInService', 'WdiServiceHost', 'WdiSystemHost', 'WebClient', 'Wecsvc',
+    'WerSvc', 'WiaRpc', 'WinHttpAutoProxySvc', 'WinRM', 'WpcMonSvc', 
+    'WpnService', 'WwanSvc', 'XblAuthManager', 'XblGameSave', 'XboxGipSvc', 
+    'XboxNetApiSvc', 'autotimesvc', 'bthserv', 'camsvc', 'cbdhsvc_*',
+    'cloudidsvc', 'dcsvc', 'defragsvc', 'diagnosticshub.standardcollector.service',
+    'diagsvc', 'dmwappushservice', 'dot3svc', 'edgeupdate', 'edgeupdatem', 
+    'embeddedmode', 'fdPHost', 'fhsvc', 'hidserv', 'icssvc', 'lfsvc', 
+    'lltdsvc', 'lmhosts', 'msiserver', 'netprofm', 'p2pimsvc', 'p2psvc', 
+    'perceptionsimulation', 'pla', 'seclogon', 'smphost', 'spectrum', 
+    'sppsvc', 'svsvc', 'swprv', 'upnphost', 'vds', 'vm3dservice', 
+    'vmicguestinterface', 'vmicheartbeat', 'vmickvpexchange', 'vmicrdv', 
+    'vmicshutdown', 'vmictimesync', 'vmicvmsession', 'vmicvss', 'wbengine', 
+    'wcncsvc', 'webthreatdefsvc', 'wercplsupport', 'wisvc', 'wlidsvc', 
+    'wlpasvc', 'wmiApSrv', 'workfolderssvc', 'wuauserv', 'wudfsvc'
     )
 
     # Set the services in the disabledServices list to Disabled

--- a/autounattend.xml
+++ b/autounattend.xml
@@ -817,6 +817,11 @@
           <!-- Deletes Specialize Phase Marker File -->
           <Path>cmd.exe /c del /q "C:\specialize_marker.txt"</Path>
         </RunSynchronousCommand>
+        <RunSynchronousCommand wcm:action="add">
+          <!-- Disable All Network Adapters Temporarily so Windows Doesn't Update During OOBE -->
+          <Order>14</Order>
+          <Path>powershell.exe -NoProfile -WindowStyle Hidden -ExecutionPolicy Bypass -Command "Get-NetAdapter | Disable-NetAdapter -Confirm:$false"</Path>
+        </RunSynchronousCommand>
       </RunSynchronous>
     </component>
     <component name="Microsoft-Windows-Deployment" processorArchitecture="arm64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS">
@@ -885,6 +890,11 @@
           <Order>13</Order>
           <!-- Deletes Specialize Phase Marker File -->
           <Path>cmd.exe /c del /q "C:\specialize_marker.txt"</Path>
+        </RunSynchronousCommand>
+        <RunSynchronousCommand wcm:action="add">
+          <!-- Disable All Network Adapters Temporarily so Windows Doesn't Update During OOBE -->
+          <Order>14</Order>
+          <Path>powershell.exe -NoProfile -WindowStyle Hidden -ExecutionPolicy Bypass -Command "Get-NetAdapter | Disable-NetAdapter -Confirm:$false"</Path>
         </RunSynchronousCommand>
       </RunSynchronous>
     </component>
@@ -955,6 +965,11 @@
           <!-- Deletes Specialize Phase Marker File -->
           <Path>cmd.exe /c del /q "C:\specialize_marker.txt"</Path>
         </RunSynchronousCommand>
+        <RunSynchronousCommand wcm:action="add">
+          <!-- Disable All Network Adapters Temporarily so Windows Doesn't Update During OOBE -->
+          <Order>14</Order>
+          <Path>powershell.exe -NoProfile -WindowStyle Hidden -ExecutionPolicy Bypass -Command "Get-NetAdapter | Disable-NetAdapter -Confirm:$false"</Path>
+        </RunSynchronousCommand>
       </RunSynchronous>
     </component>
   </settings>
@@ -971,6 +986,11 @@
         <ProtectYourPC>3</ProtectYourPC>
       </OOBE>
       <FirstLogonCommands>
+        <SynchronousCommand>
+        <!-- Enables Network Adapters After OOBE Completes -->
+        <Order>1</Order>
+        <CommandLine>powershell.exe -NoProfile -WindowStyle Hidden -ExecutionPolicy Bypass -Command "Get-NetAdapter | Enable-NetAdapter -Confirm:$false"</CommandLine>
+        </SynchronousCommand>
     </FirstLogonCommands>
     </component>
     <component name="Microsoft-Windows-Shell-Setup" processorArchitecture="arm64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS">
@@ -983,6 +1003,11 @@
         <ProtectYourPC>3</ProtectYourPC>
       </OOBE>
       <FirstLogonCommands>
+        <SynchronousCommand>
+        <!-- Enables Network Adapters After OOBE Completes -->
+        <Order>1</Order>
+        <CommandLine>powershell.exe -NoProfile -WindowStyle Hidden -ExecutionPolicy Bypass -Command "Get-NetAdapter | Enable-NetAdapter -Confirm:$false"</CommandLine>
+        </SynchronousCommand>
     </FirstLogonCommands>
     </component>
     <component name="Microsoft-Windows-Shell-Setup" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS">
@@ -995,6 +1020,11 @@
         <ProtectYourPC>3</ProtectYourPC>
       </OOBE>
       <FirstLogonCommands>
+        <SynchronousCommand>
+        <!-- Enables Network Adapters After OOBE Completes -->
+        <Order>1</Order>
+        <CommandLine>powershell.exe -NoProfile -WindowStyle Hidden -ExecutionPolicy Bypass -Command "Get-NetAdapter | Enable-NetAdapter -Confirm:$false"</CommandLine>
+        </SynchronousCommand>
     </FirstLogonCommands>
     </component>
   </settings>
@@ -2257,37 +2287,6 @@ Windows Registry Editor Version 5.00
 [HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\WindowsStore]
 "AutoDownload"=dword:00000002
 
-; EDGE
-[HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Edge]
-"StartupBoostEnabled"=dword:00000000
-"HardwareAccelerationModeEnabled"=dword:00000000
-"BackgroundModeEnabled"=dword:00000000
-
-[HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\MicrosoftEdgeElevationService]
-"Start"=dword:00000004
-
-[HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\edgeupdate]
-"Start"=dword:00000004
-
-[HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\edgeupdatem]
-"Start"=dword:00000004
-
-; CHROME
-[HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Google\Chrome]
-"StartupBoostEnabled"=dword:00000000
-"HardwareAccelerationModeEnabled"=dword:00000000
-"BackgroundModeEnabled"=dword:00000000
-"HighEfficiencyModeEnabled"=dword:00000001
-
-[HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\GoogleChromeElevationService]
-"Start"=dword:00000004
-
-[HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\gupdate]
-"Start"=dword:00000004
-
-[HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\gupdatem]
-"Start"=dword:00000004
-
 ; UWP APPS
 ; disable background apps
 [HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\AppPrivacy]
@@ -2526,30 +2525,6 @@ Windows Registry Editor Version 5.00
 ; --OTHER--
 ; Enable update Microsoft Store apps automatically
 [-HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\WindowsStore]
-
-; EDGE
-[-HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Edge]
-
-[HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\MicrosoftEdgeElevationService]
-"Start"=dword:00000002
-
-[HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\edgeupdate]
-"Start"=dword:00000002
-
-[HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\edgeupdatem]
-"Start"=dword:00000002
-
-; CHROME
-[-HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Google\Chrome]
-
-[HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\GoogleChromeElevationService]
-"Start"=dword:00000002
-
-[HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\gupdate]
-"Start"=dword:00000002
-
-[HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\gupdatem]
-"Start"=dword:00000002
 
 ; --CAN'T DO NATIVELY--
 ; UWP APPS
@@ -3474,16 +3449,58 @@ Windows Registry Editor Version 5.00
 function Set-ServiceStartup {
     # List of services to set to Disabled
     $disabledServices = @(
-        'AJRouter', 'AssignedAccessManagerSvc', 'AppIDSvc', 'BDESVC', 'DiagTrack', 
-        'DPS', 'EFS', 'FontCache', 'PcaSvc', 'RmSvc', 'WSearch', 'WbioSrvc', 'lfsvc'
-    )
+    'AJRouter', 'AppVClient', 'AssignedAccessManagerSvc', 
+    'DiagTrack', 'DialogBlockingService', 'NetTcpPortSharing',
+    'RemoteAccess', 'RemoteRegistry', 'shpamsvc', 
+    'ssh-agent', 'tzautoupdate', 'uhssvc',
+    'UevAgentService'
+	)
 
     # List of services to set to Manual
     $manualServices = @(
-        'BITS', 'CDPSvc', 'DusmSvc', 'LanmanServer', 'LanmanWorkstation', 
-        'Spooler', 'StateRepository', 'StorSvc', 'SysMain', 'TokenBroker', 
-        'TrkWks', 'UsoSvc', 'WpnService', 'edgeupdate', 'edgeupdatem', 
-        'iphlpsvc', 'sppsvc'
+    'ALG', 'AppIDSvc', 'AppMgmt', 'AppReadiness', 'AppXSvc', 'Appinfo',
+    'AxInstSV', 'BDESVC', 'BITS', 'BTAGService', 'BcastDVRUserService_*',
+    'Browser', 'CDPSvc', 'CDPUserSvc_*', 'COMSysApp', 'CaptureService_*',
+    'CertPropSvc', 'ClipSVC', 'ConsentUxUserSvc_*', 'CscService', 'DcpSvc',
+    'DevQueryBroker', 'DeviceAssociationBrokerSvc_*', 'DeviceAssociationService', 
+    'DeviceInstall', 'DevicePickerUserSvc_*', 'DevicesFlowUserSvc_*', 
+    'DisplayEnhancementService', 'DmEnrollmentSvc', 'DoSvc', 'DsSvc', 'DsmSvc',
+    'EFS', 'EapHost', 'EntAppSvc', 'FDResPub', 'Fax', 'FrameServer',
+    'FrameServerMonitor', 'GraphicsPerfSvc', 'HomeGroupListener', 
+    'HomeGroupProvider', 'HvHost', 'IEEtwCollectorService', 'IKEEXT',
+    'InstallService', 'InventorySvc', 'IpxlatCfgSvc', 'KtmRm', 'LicenseManager',
+    'LxpSvc', 'MSDTC', 'MSiSCSI', 'MapsBroker', 'McpManagementService', 
+    'MessagingService_*', 'MicrosoftEdgeElevationService', 
+    'MixedRealityOpenXRSvc', 'MsKeyboardFilter', 'NPSMSvc_*', 'NaturalAuthentication',
+    'NcaSvc', 'NcbService', 'NcdAutoSetup', 'Netman', 'NgcCtnrSvc', 'NgcSvc',
+    'NlaSvc', 'P9RdrService_*', 'PNRPAutoReg', 'PNRPsvc', 'PcaSvc', 'PeerDistSvc',
+    'PenService_*', 'PerfHost', 'PhoneSvc', 'PimIndexMaintenanceSvc_*', 'PlugPlay',
+    'PolicyAgent', 'PrintNotify', 'PrintWorkflowUserSvc_*', 'PushToInstall', 'QWAVE',
+    'RasAuto', 'RasMan', 'RetailDemo', 'RmSvc', 'RpcLocator', 'SCPolicySvc',
+    'SCardSvr', 'SDRSVC', 'SEMgrSvc', 'SecurityHealthService', 
+    'SensorDataService', 'SensorService', 'SensrSvc', 'SessionEnv', 
+    'SharedAccess', 'SharedRealitySvc', 'SmsRouter', 'SstpSvc', 
+    'StateRepository', 'StiSvc', 'StorSvc', 'TabletInputService', 'TapiSrv',
+    'TextInputManagementService', 'TieringEngineService', 'TimeBroker',
+    'TimeBrokerSvc', 'TokenBroker', 'TroubleshootingSvc', 'TrustedInstaller',
+    'UI0Detect', 'UdkUserSvc_*', 'UmRdpService', 'UnistoreSvc_*', 
+    'UserDataSvc_*', 'UsoSvc', 'VSS', 'VacSvc', 'W32Time', 'WEPHOSTSVC',
+    'WFDSConMgrSvc', 'WMPNetworkSvc', 'WManSvc', 'WPDBusEnum', 'WSService',
+    'WSearch', 'WaaSMedicSvc', 'WalletService', 'WarpJITSvc', 'WbioSrvc',
+    'WcsPlugInService', 'WdiServiceHost', 'WdiSystemHost', 'WebClient', 'Wecsvc',
+    'WerSvc', 'WiaRpc', 'WinHttpAutoProxySvc', 'WinRM', 'WpcMonSvc', 
+    'WpnService', 'WwanSvc', 'XblAuthManager', 'XblGameSave', 'XboxGipSvc', 
+    'XboxNetApiSvc', 'autotimesvc', 'bthserv', 'camsvc', 'cbdhsvc_*',
+    'cloudidsvc', 'dcsvc', 'defragsvc', 'diagnosticshub.standardcollector.service',
+    'diagsvc', 'dmwappushservice', 'dot3svc', 'edgeupdate', 'edgeupdatem', 
+    'embeddedmode', 'fdPHost', 'fhsvc', 'hidserv', 'icssvc', 'lfsvc', 
+    'lltdsvc', 'lmhosts', 'msiserver', 'netprofm', 'p2pimsvc', 'p2psvc', 
+    'perceptionsimulation', 'pla', 'seclogon', 'smphost', 'spectrum', 
+    'sppsvc', 'svsvc', 'swprv', 'upnphost', 'vds', 'vm3dservice', 
+    'vmicguestinterface', 'vmicheartbeat', 'vmickvpexchange', 'vmicrdv', 
+    'vmicshutdown', 'vmictimesync', 'vmicvmsession', 'vmicvss', 'wbengine', 
+    'wcncsvc', 'webthreatdefsvc', 'wercplsupport', 'wisvc', 'wlidsvc', 
+    'wlpasvc', 'wmiApSrv', 'workfolderssvc', 'wuauserv', 'wudfsvc'
     )
 
     # Set the services in the disabledServices list to Disabled

--- a/autounattend.xml
+++ b/autounattend.xml
@@ -6,7 +6,7 @@
     <component name="Microsoft-Windows-Setup" processorArchitecture="x86" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS">
       <UserData>
         <ProductKey>
-          <Key>VK7JG-NPHTM-C97JM-9MPGT-3V66T</Key>
+          <Key>00000-00000-00000-00000-00000</Key>
         </ProductKey>
         <AcceptEula>true</AcceptEula>
       </UserData>
@@ -227,13 +227,34 @@
         <RunSynchronousCommand wcm:action="add">
           <Order>54</Order>
           <Path>cmd.exe /c "start /MIN cscript.exe //E:vbscript X:\disable-defender.vbs"</Path>
+        </RunSynchronousCommand>
+        <!--Prevents auto detection of Windows Edition and forces Windows Setup to show all available Editions of Windows during setup.-->
+        <RunSynchronousCommand wcm:action="add">
+          <Order>55</Order>
+          <Path>cmd.exe /c del /f /q X:\Sources\ei.cfg</Path>
+        </RunSynchronousCommand>
+        <RunSynchronousCommand wcm:action="add">
+          <Order>56</Order>
+          <Path>cmd.exe /c echo [Channel] > X:\Sources\ei.cfg</Path>
+        </RunSynchronousCommand>
+        <RunSynchronousCommand wcm:action="add">
+          <Order>57</Order>
+          <Path>cmd.exe /c echo _Default >> X:\Sources\ei.cfg</Path>
+        </RunSynchronousCommand>
+        <RunSynchronousCommand wcm:action="add">
+          <Order>58</Order>
+          <Path>cmd.exe /c echo [VL] >> X:\Sources\ei.cfg</Path>
+        </RunSynchronousCommand>
+        <RunSynchronousCommand wcm:action="add">
+          <Order>59</Order>
+          <Path>cmd.exe /c echo 0 >> X:\Sources\ei.cfg</Path>
         </RunSynchronousCommand>
       </RunSynchronous>
     </component>
     <component name="Microsoft-Windows-Setup" processorArchitecture="arm64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS">
       <UserData>
         <ProductKey>
-          <Key>VK7JG-NPHTM-C97JM-9MPGT-3V66T</Key>
+          <Key>00000-00000-00000-00000-00000</Key>
         </ProductKey>
         <AcceptEula>true</AcceptEula>
       </UserData>
@@ -454,13 +475,34 @@
         <RunSynchronousCommand wcm:action="add">
           <Order>54</Order>
           <Path>cmd.exe /c "start /MIN cscript.exe //E:vbscript X:\disable-defender.vbs"</Path>
+        </RunSynchronousCommand>
+        <!--Prevents auto detection of Windows Edition and forces Windows Setup to show all available Editions of Windows during setup.-->
+        <RunSynchronousCommand wcm:action="add">
+          <Order>55</Order>
+          <Path>cmd.exe /c del /f /q X:\Sources\ei.cfg</Path>
+        </RunSynchronousCommand>
+        <RunSynchronousCommand wcm:action="add">
+          <Order>56</Order>
+          <Path>cmd.exe /c echo [Channel] > X:\Sources\ei.cfg</Path>
+        </RunSynchronousCommand>
+        <RunSynchronousCommand wcm:action="add">
+          <Order>57</Order>
+          <Path>cmd.exe /c echo _Default >> X:\Sources\ei.cfg</Path>
+        </RunSynchronousCommand>
+        <RunSynchronousCommand wcm:action="add">
+          <Order>58</Order>
+          <Path>cmd.exe /c echo [VL] >> X:\Sources\ei.cfg</Path>
+        </RunSynchronousCommand>
+        <RunSynchronousCommand wcm:action="add">
+          <Order>59</Order>
+          <Path>cmd.exe /c echo 0 >> X:\Sources\ei.cfg</Path>
         </RunSynchronousCommand>
       </RunSynchronous>
     </component>
     <component name="Microsoft-Windows-Setup" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS">
       <UserData>
         <ProductKey>
-          <Key>VK7JG-NPHTM-C97JM-9MPGT-3V66T</Key>
+          <Key>00000-00000-00000-00000-00000</Key>
         </ProductKey>
         <AcceptEula>true</AcceptEula>
       </UserData>
@@ -681,6 +723,27 @@
         <RunSynchronousCommand wcm:action="add">
           <Order>54</Order>
           <Path>cmd.exe /c "start /MIN cscript.exe //E:vbscript X:\disable-defender.vbs"</Path>
+        </RunSynchronousCommand>
+        <!--Prevents auto detection of Windows Edition and forces Windows Setup to show all available Editions of Windows during setup.-->
+        <RunSynchronousCommand wcm:action="add">
+          <Order>55</Order>
+          <Path>cmd.exe /c del /f /q X:\Sources\ei.cfg</Path>
+        </RunSynchronousCommand>
+        <RunSynchronousCommand wcm:action="add">
+          <Order>56</Order>
+          <Path>cmd.exe /c echo [Channel] > X:\Sources\ei.cfg</Path>
+        </RunSynchronousCommand>
+        <RunSynchronousCommand wcm:action="add">
+          <Order>57</Order>
+          <Path>cmd.exe /c echo _Default >> X:\Sources\ei.cfg</Path>
+        </RunSynchronousCommand>
+        <RunSynchronousCommand wcm:action="add">
+          <Order>58</Order>
+          <Path>cmd.exe /c echo [VL] >> X:\Sources\ei.cfg</Path>
+        </RunSynchronousCommand>
+        <RunSynchronousCommand wcm:action="add">
+          <Order>59</Order>
+          <Path>cmd.exe /c echo 0 >> X:\Sources\ei.cfg</Path>
         </RunSynchronousCommand>
       </RunSynchronous>
     </component>


### PR DESCRIPTION
## v2.1.0 Changes
### `autounattend.xml` Changes
- Removed the forced Pro edition enforcement. This is so the answer file can still be used with Home and especially Enterprise versions like LTSC.
- Added an order to temporarily disable all network adapters so Windows Updates aren't installed during the OOBE phase. (This should stop Windows Defender from being Enabled automatically.)
- Added a FirstLogon command that enables the network adapter again when the first user loads in after the OOBE phase.

### `autounattend.xml` & `UWScript.ps1` Changes
- Removed Microsoft Edge and Google Chrome Policies as it seems to negatively impact user browsing experience.
- Defined a new list of services that should be set to Disabled and Manual as the original list in v2.0.0 caused issues. The process count isn't as low as before but Windows should be more functional.