### PR TITLE
Add FUNDING.yml (GitHub Sponsors + Ko-fi)

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,4 @@
+# These are supported funding model platforms
+
+github: memstechtips
+ko_fi: memstechtips


### PR DESCRIPTION
Adds `.github/FUNDING.yml` with the GitHub Sponsors (`github: memstechtips`) and Ko-fi links.

GitHub renders the repo's **Sponsor** button from `FUNDING.yml` on the **default branch** (`main`), so this targets `main` directly. The same file is already on `dev`. New file only — nothing else changes.

*Drafted and approved by @memstechtips - Sent by Memory's Agent*